### PR TITLE
Fix rejoin bug

### DIFF
--- a/src/protocol/packet/pkt_character.rs
+++ b/src/protocol/packet/pkt_character.rs
@@ -27,9 +27,9 @@ pub struct Character {
 }
 
 impl Character {
-    pub fn from(author: Option<Stream>, incoming: &Character) -> Self {
+    pub fn to_default(incoming: &Character) -> Self {
         Character {
-            author,
+            author: incoming.author.clone(),
             message_type: incoming.message_type,
             name: incoming.name.clone(),
             flags: CharacterFlags::default(),

--- a/src/threads/server.rs
+++ b/src/threads/server.rs
@@ -550,13 +550,13 @@ pub fn server(receiver: Arc<Mutex<Receiver<Protocol>>>, map: &mut Map) {
 
                 room.players.retain(|&idx| idx != player_idx);
 
-                // map.message_room(
-                //     old_room_number,
-                //     format!("{}'s corpse disappeared into a puff of smoke.", player_name),
-                // )
-                // .unwrap_or_else(|e| {
-                //     error!("[SERVER] Failed to message room: {}", e);
-                // });
+                map.message_room(
+                    old_room_number,
+                    format!("{}'s corpse disappeared into a puff of smoke.", player_name),
+                )
+                .unwrap_or_else(|e| {
+                    error!("[SERVER] Failed to message room: {}", e);
+                });
 
                 // TODO: We also need to alert the old room that the "body" disappears
                 // ^ ============================================================================ ^

--- a/src/threads/server.rs
+++ b/src/threads/server.rs
@@ -526,12 +526,13 @@ pub fn server(receiver: Arc<Mutex<Receiver<Protocol>>>, map: &mut Map) {
                     continue;
                 }
 
+                let player_clone = player.clone(); // Borrow and mutability band-aids :smil:
                 let player_name = player.name.clone();
 
                 let player_idx = match map.players.iter().position(|p| p.name == player_name) {
                     Some(idx) => idx,
                     None => {
-                        warn!("[SERVER] Unable to find player {} in map", player_name);
+                        warn!("[SERVER] Unable to find player in map");
                         continue;
                     }
                 };
@@ -558,7 +559,10 @@ pub fn server(receiver: Arc<Mutex<Receiver<Protocol>>>, map: &mut Map) {
                     error!("[SERVER] Failed to message room: {}", e);
                 });
 
-                // TODO: We also need to alert the old room that the "body" disappears
+                map.alert_room(old_room_number, &player_clone)
+                    .unwrap_or_else(|e| {
+                        warn!("[SERVER] Failed to alert players: {}", e);
+                    });
                 // ^ ============================================================================ ^
             }
             Protocol::Leave(author, content) => {


### PR DESCRIPTION
When a player joins, moves to a room, leaves, rejoins (back in room 0), then attempts to move back the server will send you an error saying you are already in that room... which is not true!