### PR TITLE
Implemented HashMaps and Decoupling 

### DIFF
--- a/src/content/deku-tree.json
+++ b/src/content/deku-tree.json
@@ -2,13 +2,13 @@
     {
         "room_number": 0,
         "title": "Outside the Great Deku Tree",
-        "connections": [
-            {
+        "connections": {
+            "1": {
                 "room_number": 1,
                 "title": "F1 - Main Hall",
                 "desc_short": "You cannot see what lies beyond the darkness of the Deku Tree's maw, but his pleas for help must not go unanswered!"
             }
-        ],
+        },
         "desc": "The dense forest clears just enough to reveal a towering presence nestled among the ancient woods the Great Deku Tree, guardian spirit of the forest. Its colossal trunk rises like a fortress of living wood, bark gnarled with age and wisdom beyond imagining. Broad roots snake across the ground like the limbs of slumbering giants, parting gently around a hollow arch that serves as its mouth-like entrance. A faint, warm glow pulses from within, as if the tree's heart beats just beyond the threshold. The canopy above filters sunlight into dappled emerald patterns that dance on the forest floor, and the air is thick with the scent of wild herbs and old magic. As you approach, the wind carries a soft whisper; whether from the tree itself or the spirits it shelters, you cannot tell. The path forward narrows, inviting only those with purpose... and courage.",
         "players": [],
         "monsters": [
@@ -25,18 +25,18 @@
     {
         "room_number": 1,
         "title": "F1 - Main Hall",
-        "connections": [
-            {
+        "connections": {
+            "0": {
                 "room_number": 0,
                 "title": "Outside the Great Deku Tree",
                 "desc_short": "A clearing in the Kokiri Forest where the Great Deku Tree resides."
             },
-            {
+            "2": {
                 "room_number": 2,
                 "title": "F1 - Spiral Staircase",
                 "desc_short": "A set of vines lead up towards a moss-covered wooden boardwalk that winds up to Deku Tree."
             }
-        ],
+        },
         "desc": "You step into the heartwood chamber of the ancient Great Deku Tree, where the air is thick with the scent of moss and damp bark. The room opens into a massive vertical hollow, its walls curving upward like the inside of a colossal oak, disappearing into shadowed heights above. Shafts of golden light pierce through cracks in the bark high above, casting shifting patterns on the moss-laden floor. Thick roots twist through the walls like frozen serpents, and narrow wooden platforms cling precariously to the inner curve of the trunk, forming a spiraling path toward unseen levels above. The soft skittering of insect legs echoes from the darkness, and the glint of many-eyed Skulltulas clinging to web-choked passages sends a chill down your spine. in the center of the room lays an unusually large spider web that you can't seem to break, but you can see light on the other side.",
         "players": [],
         "monsters": [
@@ -69,18 +69,18 @@
     {
         "room_number": 2,
         "title": "F1 - Spiral Staircase",
-        "connections": [
-            {
+        "connections": {
+            "1": {
                 "room_number": 1,
                 "title": "F1 - Main Hall",
                 "desc_short": "You cannot see what lies beyond the darkness of the Deku Tree's maw, but his pleas for help must not go unanswered!"
             },
-            {
+            "3": {
                 "room_number": 3,
                 "title": "F2 - Spiral Staircase Lower",
                 "desc_short": "A moss-covered boardwalk that winds upwards towards the tree's canopy."
             }
-        ],
+        },
         "desc": "A narrow, moss-covered ledge high above the main hall, reached by climbing thick, winding vines. From here, the vast chamber stretches below, roots twist around the walls, and faint light filters in from cracks above. As you look up you see a small staircase that winds upwards into the darkness above.",
         "players": [],
         "monsters": []
@@ -88,23 +88,23 @@
     {
         "room_number": 3,
         "title": "F2 - Spiral Staircase Lower",
-        "connections": [
-            {
+        "connections": {
+            "2": {
                 "room_number": 2,
                 "title": "F1 - Spiral Staircase",
                 "desc_short": "A set of vines lead up towards a moss-covered wooden boardwalk that winds up to Deku Tree."
             },
-            {
+            "4": {
                 "room_number": 4,
                 "title": "F2 - Spiral Staircase Upper",
                 "desc_short": "Beyond the gap, the stairs narrow, a door way lays ahead."
             },
-            {
+            "5": {
                 "room_number": 5,
                 "title": "3F - Upper Boardwalk",
                 "desc_short": "A narrow, circular boardwalk that wraps around the upper trunk."
             }
-        ],
+        },
         "desc": "A moss-covered boardwalk winds upwards towards the canopy. Midway up, a narrow gap breaks the path, the wall is covered in vines that may bring you higher, but some enemies may block your path.",
         "players": [],
         "monsters": [
@@ -137,18 +137,18 @@
     {
         "room_number": 4,
         "title": "F2 - Spiral Staircase Upper",
-        "connections": [
-            {
+        "connections": {
+            "3": {
                 "room_number": 3,
                 "title": "F2 - Spiral Staircase Lower",
                 "desc_short": "A moss-covered boardwalk that winds upwards towards the tree's canopy."
             },
-            {
+            "7": {
                 "room_number": 7,
                 "title": "F2 - Deku Scrub Guard",
                 "desc_short": "A small opening, chirping can be heard from inside."
             }
-        ],
+        },
         "desc": "Beyond the gap, the spiral narrows, the bark slick with moisture. Along the left wall, partially hidden by hanging roots, a small wooden doorway is set into the trunk. Just beyond, the path curves upward toward a ledge, where the sounds of hostile creatures stir.",
         "players": [],
         "monsters": [
@@ -173,23 +173,23 @@
     {
         "room_number": 5,
         "title": "3F - Upper Boardwalk",
-        "connections": [
-            {
+        "connections": {
+            "4": {
                 "room_number": 4,
                 "title": "F2 - Spiral Staircase Upper",
                 "desc_short": "Beyond the gap, the stairs narrow, a door way lays ahead."
             },
-            {
+            "6": {
                 "room_number": 6,
                 "title": "B1 - Depths",
                 "desc_short": "A large spider web blocks the way down, maybe jumping from way up here will break your fall and make it give way?"
             },
-            {
+            "9": {
                 "room_number": 9,
                 "title": "F3 - Pillar Room Start",
                 "desc_short": "A quiet chamber full of secrets."
             }
-        ],
+        },
         "desc": "Climbing the thick vines, you emerge onto a narrow, circular boardwalk that wraps around the upper trunk. The tree is covered head to toe in spider webs. The center is open, revealing the vast hall below... Maybe you could jump and break the web below? Three Skulltulas hang from wooden ledges protruding through the webs, their eyes tracking your every movement. A doorway is visible on the far side, leading further into the tree, its frame partially obscured by tangled vines.",
         "players": [],
         "monsters": [
@@ -222,18 +222,18 @@
     {
         "room_number": 6,
         "title": "B1 - Depths",
-        "connections": [
-            {
+        "connections": {
+            "1": {
                 "room_number": 1,
                 "title": "F1 - Main Hall",
                 "desc_short": "A towering column of wood and roots, leading back to the main hall."
             },
-            {
+            "13": {
                 "room_number": 13,
                 "title": "B1 - Spider's Den",
                 "desc_short": "The only way forward."
             }
-        ],
+        },
         "desc": "As the web gives way beneath your weight, you plunge into the damp darkness below. A splash echoes through the chamber as you land in a shallow pool, its water cool and murky. The air here is thick with moisture and decay, heavy with the scent of moss and rot. Torches lining the walls, casting a ghostly glow that dances across twisted roots and crumbling bark. Strange skittering noises echo from the shadows, and the rhythmic dripping of water adds to the eerie ambiance. You sense the heart of the corruption lurking deeper within--something ancient, watching, waiting.",
         "players": [],
         "monsters": [
@@ -258,18 +258,18 @@
     {
         "room_number": 7,
         "title": "F2 - Deku Scrub Guard",
-        "connections": [
-            {
+        "connections": {
+            "4": {
                 "room_number": 4,
                 "title": "F2 - Spiral Staircase Upper",
                 "desc_short": "Beyond the gap, the stairs narrow, a door way lays ahead."
             },
-            {
+            "8": {
                 "room_number": 8,
                 "title": "F2 - Treasure Room",
                 "desc_short": "A small room with a high ledge, you can barely make out the room's contents."
             }
-        ],
+        },
         "desc": "A semi-large room with a Deku Scrub in the center, periodically shooting Deku Seeds at you. Defeating it may provide more valuable than it may seem...",
         "players": [],
         "monsters": [
@@ -286,13 +286,13 @@
     {
         "room_number": 8,
         "title": "F2 - Treasure Room",
-        "connections": [
-            {
+        "connections": {
+            "7": {
                 "room_number": 7,
                 "title": "F2 - Deku Scrub Guard",
                 "desc_short": "A small opening, chirping can be heard from inside."
             }
-        ],
+        },
         "desc": "After defeating the guard you reach another ledge, atop you see a large chest. The air is thick with the smell of moss and wood, and soft light emits from nearby torches.",
         "players": [],
         "monsters": [
@@ -309,18 +309,18 @@
     {
         "room_number": 9,
         "title": "F3 - Pillar Room Start",
-        "connections": [
-            {
+        "connections": {
+            "5": {
                 "room_number": 5,
                 "title": "3F - Upper Boardwalk",
                 "desc_short": "A narrow, circular boardwalk that wraps around the upper trunk."
             },
-            {
+            "10": {
                 "room_number": 10,
                 "title": "F3 - Pillars",
                 "desc_short": "A set of 3 stone pillars protruding from the floor."
             }
-        ],
+        },
         "desc": "You step cautiously into a quiet chamber perched high within the Great Deku Tree. The bark creaks beneath your feet, and immediately, your eyes are drawn to a stone button embedded off to the side. A lone unlit torch stands sentinel near the wall, its sconce cold and unused. In front of you, across a small gap, a treasure chest rests atop a raised platform--tempting, but just out of reach. Pillars of stone protrude from the ground at uneven heights, clearly designed to shift or rise with some mechanism. Off to the right, a shadowy alcove breaks the symmetry of the room, its purpose unclear but suspiciously placed.",
         "players": [],
         "monsters": []
@@ -328,23 +328,23 @@
     {
         "room_number": 10,
         "title": "F3 - Pillars",
-        "connections": [
-            {
+        "connections": {
+            "9": {
                 "room_number": 9,
                 "title": "F3 - Pillar Room Start",
                 "desc_short": "A quiet chamber full of secrets."
             },
-            {
+            "11": {
                 "room_number": 11,
                 "title": "F3 - Hidden Alcove",
                 "desc_short": "A small opening slightly covered in vines."
             },
-            {
+            "12": {
                 "room_number": 12,
                 "title": "F3 - Pillar's Treasure",
                 "desc_short": "You better hurry, your reward lay just ahead!"
             }
-        ],
+        },
         "desc": "You carefully step one-by-one onto the stone pillars, the sound of clicking fills the room as if a timer is about to go off. You can hear faint clicking noises coming from somewhere in the room. The alcove just to the side beckons you to explore.",
         "players": [],
         "monsters": []
@@ -352,13 +352,13 @@
     {
         "room_number": 11,
         "title": "F3 - Hidden Alcove",
-        "connections": [
-            {
+        "connections": {
+            "10": {
                 "room_number": 10,
                 "title": "F3 - Pillars",
                 "desc_short": "A set of 3 stone pillars protruding from the floor."
             }
-        ],
+        },
         "desc": "Tucked into the side wall, the alcove is partially hidden in shadow, as though the tree itself is trying to keep it secret. The space is small--just large enough for a person to step into--but its walls curve gently inward, carved naturally from the wood of the Great Deku Tree. Faint scratch marks line the entrance, as if something once tried to claw its way out… or in. A small chest is perched in the center.",
         "players": [],
         "monsters": [
@@ -383,13 +383,13 @@
     {
         "room_number": 12,
         "title": "F3 - Pillar's Treasure",
-        "connections": [
-            {
+        "connections": {
+            "10": {
                 "room_number": 10,
                 "title": "F3 - Pillars",
                 "desc_short": "A set of 3 stone pillars protruding from the floor."
             }
-        ],
+        },
         "desc": "After jumping from the last pillar you can see a treasure chest on the back wall. Some bushes are growing in the moss nearby.",
         "players": [],
         "monsters": [
@@ -406,18 +406,18 @@
     {
         "room_number": 13,
         "title": "B1 - Spider's Den",
-        "connections": [
-            {
+        "connections": {
+            "6": {
                 "room_number": 6,
                 "title": "B1 - Depths",
                 "desc_short": "A large open room at the base of the Deku Tree."
             },
-            {
+            "14": {
                 "room_number": 14,
                 "title": "B1 - Flooded Cave",
                 "desc_short": "A small flooded chamber full of danger."
             }
-        ],
+        },
         "desc": "A small room covered completely in spiderwebs. The exit lays just beyond a handful of spiders.",
         "players": [],
         "monsters": []
@@ -425,23 +425,23 @@
     {
         "room_number": 14,
         "title": "B1 - Flooded Cave",
-        "connections": [
-            {
+        "connections": {
+            "13": {
                 "room_number": 13,
                 "title": "B1 - Spider's Den",
                 "desc_short": "The only way forward."
             },
-            {
+            "15": {
                 "room_number": 15,
                 "title": "B1 - Water",
                 "desc_short": "It stinks..."
             },
-            {
+            "16": {
                 "room_number": 16,
                 "title": "B1 - Torch Room",
                 "desc_short": "A faint glow can be seen beneath the doorway, snapping can be heard from within."
             }
-        ],
+        },
         "desc": "You descend deeper into the tree's heart and find yourself in a wide, flooded chamber where time feels slow and uncertain. The murky water laps quietly at the base of the walls, rippling with the soft motion of a wooden platform that glides steadily across the surface. It moves back and forth, almost lazily, as if rocked by the tree's breath. Just overhead, a massive spiked pillar sweeps horizontally in a deadly rhythm, its rusted iron head groaning with every pass—timing is everything.",
         "players": [],
         "monsters": [
@@ -458,13 +458,13 @@
     {
         "room_number": 15,
         "title": "B1 - Water",
-        "connections": [
-            {
+        "connections": {
+            "14": {
                 "room_number": 14,
                 "title": "B1 - Flooded Cave",
                 "desc_short": "A small flooded chamber full of danger."
             }
-        ],
+        },
         "desc": "You fall into the dark and opaque water below, swirling with silt and bits of decaying bark. It clings to you with a sluggish resistance, cool and foul-smelling, as though it hasn't been disturbed in ages. Beneath the surface, shifting shapes flicker just out of sight—whether drifting debris or something alive, it's hard to tell. Every movement sends soft ripples across the pool, distorting reflections and masking the true depth. The water doesn't just fill the room—it feels like it soaks into it, seeping into every crevice of the ancient wood like a slow, creeping rot.",
         "players": [],
         "monsters": []
@@ -472,18 +472,18 @@
     {
         "room_number": 16,
         "title": "B1 - Torch Room",
-        "connections": [
-            {
+        "connections": {
+            "14": {
                 "room_number": 14,
                 "title": "B1 - Flooded Cave",
                 "desc_short": "A small flooded chamber full of danger."
             },
-            {
+            "17": {
                 "room_number": 17,
                 "title": "B1 - Suspiciously Empty Room",
                 "desc_short": "A large room coated in webs."
             }
-        ],
+        },
         "desc": "Beyond the dripping exit lies a smaller chamber, dimly lit and heavy with tension. Three torches stand in a rough triangle at the center of the room two cold and dark, one already flickering with an unsteady flame. Their glow casts warped shadows that dance across the bark-lined walls. Against one side, a pair of Deku Babas stand rooted, their twisted stalks swaying as they sense movement. A third lurks nearer the center, its snapping jaws inches from the unlit torches, as if guarding something. Overhead, a lone Keese circles slowly, its wings rustling softly in the stale air. The room feels like a trial--solve the flame, survive the guardians, and move forward.",
         "players": [],
         "monsters": [
@@ -524,23 +524,23 @@
     {
         "room_number": 17,
         "title": "B1 - Suspiciously Empty Room",
-        "connections": [
-            {
+        "connections": {
+            "16": {
                 "room_number": 16,
                 "title": "B1 - Torch Room",
                 "desc_short": "A faint glow can be seen beneath the doorway, snapping can be heard from within."
             },
-            {
+            "18": {
                 "room_number": 18,
                 "title": "B1 - Small Opening",
                 "desc_short": "Why is there a random doorway here?"
             },
-            {
+            "19": {
                 "room_number": 19,
                 "title": "B1 - Crawlspace",
                 "desc_short": "A small opening just big enough for you to crawl through"
             }
-        ],
+        },
         "desc": "Once you lit the torches the way forward opened up. A couple torches are dotted along the wall. As you enter a Skulltula blocks your path. Ahead of you, on the ceiling you can just barely make out 3 rather large pulsating sacks...",
         "players": [],
         "monsters": [
@@ -589,13 +589,13 @@
     {
         "room_number": 18,
         "title": "B1 - Small Opening",
-        "connections": [
-            {
+        "connections": {
+            "17": {
                 "room_number": 17,
                 "title": "B1 - Suspiciously Empty Room",
                 "desc_short": "A large room coated in webs."
             }
-        ],
+        },
         "desc": "You found a secret room hidden beyond the opening! A skulltula circles back and forth at the rear wall and a golden skulltula clings to the wall.",
         "players": [],
         "monsters": [
@@ -620,18 +620,18 @@
     {
         "room_number": 19,
         "title": "B1 - Crawlspace",
-        "connections": [
-            {
+        "connections": {
+            "17": {
                 "room_number": 17,
                 "title": "B1 - Suspiciously Empty Room",
                 "desc_short": "A large room coated in webs."
             },
-            {
+            "20": {
                 "room_number": 20,
                 "title": "B1 - Upper Depths",
                 "desc_short": "The light at the end of the tunnel."
             }
-        ],
+        },
         "desc": "Slowly crawling to the other side you can see the glowing light of torches at the end of the tunnel. Water drips on your face as a handful of insects scurry behind you.",
         "players": [],
         "monsters": []
@@ -639,23 +639,23 @@
     {
         "room_number": 20,
         "title": "B1 - Upper Depths",
-        "connections": [
-            {
+        "connections": {
+            "6": {
                 "room_number": 6,
                 "title": "B1 - Depths",
                 "desc_short": "A large spider web blocks the way down, maybe jumping from way up here will break your fall and make it give way?"
             },
-            {
+            "19": {
                 "room_number": 19,
                 "title": "B1 - Crawlspace",
                 "desc_short": "A small opening just big enough for you to crawl through"
             },
-            {
+            "21": {
                 "room_number": 21,
                 "title": "B2 - Deku Tree Roots",
                 "desc_short": "A deep opening that leads to the root of the Great Deku Tree. An ominous aura leaks betwixt the gaps in the web. A sense of great evil beneath."
             }
-        ],
+        },
         "desc": "A previously unreachable section of the Depths. Another large web covers the opening that leads deeper into the Deku Tree's roots. Off to the side of the hole a pair of Deku Babas snap at your feet.",
         "players": [],
         "monsters": [
@@ -688,18 +688,18 @@
     {
         "room_number": 21,
         "title": "B2 - Deku Tree Roots",
-        "connections": [
-            {
+        "connections": {
+            "20": {
                 "room_number": 20,
                 "title": "B1 - Upper Depths",
                 "desc_short": "The light at the end of the tunnel."
             },
-            {
+            "22": {
                 "room_number": 22,
                 "title": "B2 - Queen Gohma's Chamber",
                 "desc_short": "Darkness oozes from cracks in the door, you must get to the other side!"
             }
-        ],
+        },
         "desc": "After burning away the webs you fall for what feels like forever, the world blurring past in streaks of bark and shadow. Then, suddenly, you crash into a deep pool far below. The water is cold and strangely still, muffling the sounds of the ancient tree's creaks and groans. As you surface, the chamber around you reveals itself: vast, round, and alive with the quiet hum of age and mystery. Ahead, the pool tapers into a mossy landing where three Deku Scrubs stand along the back wall. They eye you warily, retreating into their hiding spots when threatened, only to pop back up at shoot deku seeds at you. Off to the side stands a thick wooden door bound in iron locked tight. The path forward is sealed not by strength, but by memory and wit. The tree's final challenge lies before you.",
         "players": [],
         "monsters": [
@@ -740,13 +740,13 @@
     {
         "room_number": 22,
         "title": "B2 - Queen Gohma's Chamber",
-        "connections": [
-            {
+        "connections": {
+            "21": {
                 "room_number": 21,
                 "title": "B2 - Deku Tree Roots",
                 "desc_short": "A deep opening that leads to the root of the Great Deku Tree. An ominous aura leaks betwixt the gaps in the web. A sense of great evil beneath."
             }
-        ],
+        },
         "desc": "You step into a vast, ominous chamber, the air thick with the scent of decay and ancient dread. The room feels cavernous, its walls stretching up and out, where the faintest echoes of your footsteps linger like whispers. In the center of the room, four stone pillars rise, weathered and cracked, standing like sentinels around an eerie stillness. Above you, the ceiling is dark and cavernous, with twisted roots hanging like curtains, obscuring what lies hidden. As you move further into the chamber, you feel an unsettling chill creeping down your spine. For a moment, there is nothing. But then, from the shadows above, you see her gleaming, unblinking eye as she stares down at you. The ceiling begins to tremble, and Queen Gohma's massive, arachnid form unfurls from her dormant state, her red eye glowing with malicious intent.",
         "players": [],
         "monsters": [

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::net::TcpListener;
 use std::sync::{Arc, Mutex, mpsc};
 use tracing::{debug, info, warn};
 
-use crate::protocol::game::Map;
+use crate::protocol::game;
 use crate::threads::{processor::connection, server::server};
 
 pub mod protocol;
@@ -37,13 +37,13 @@ fn main() -> ! {
     // Build the game map
     let path = env::var("MAP_FILEPATH").expect("[MAIN] MAP_FILEPATH must be set.");
     let file = File::open(path).expect("[MAIN] Failed to open map file!");
-    let mut map = Map::build(file).expect("[MAIN] Failed to build map from file");
+    let mut rooms = game::build(file).expect("[MAIN] Failed to build map from file");
 
     // Start the server thread with the map
     info!("[MAIN] Parsed map successfully");
 
     let _ = std::thread::spawn(move || {
-        server(receiver, &mut map);
+        server(receiver, &mut rooms);
     });
 
     loop {

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@ use std::net::TcpListener;
 use std::sync::{Arc, Mutex, mpsc};
 use tracing::{debug, info, warn};
 
-use crate::protocol::map::Map;
+use crate::protocol::game::Map;
 use crate::threads::{processor::connection, server::server};
 
 pub mod protocol;
@@ -39,9 +39,6 @@ fn main() -> ! {
     let file = File::open(path).expect("[MAIN] Failed to open map file!");
     let mut map = Map::build(file).expect("[MAIN] Failed to build map from file");
 
-    let initial_points = map.init_points;
-    let stat_limit = map.stat_limit;
-
     // Start the server thread with the map
     info!("[MAIN] Parsed map successfully");
 
@@ -59,7 +56,7 @@ fn main() -> ! {
 
                 // Handle the connection in a separate thread
                 let client_h = std::thread::spawn(move || {
-                    connection(stream, initial_points, stat_limit, sender);
+                    connection(stream, sender);
                 });
 
                 debug!("[MAIN] Spawned client thread: {:?}", client_h.thread().id());

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -9,7 +9,7 @@ pub type Stream = Arc<TcpStream>;
 
 pub mod client;
 pub mod error;
-pub mod map;
+pub mod game;
 pub mod packet;
 pub mod pcap;
 pub mod pkt_type;

--- a/src/protocol/game.rs
+++ b/src/protocol/game.rs
@@ -8,13 +8,6 @@ use crate::protocol::{
     pkt_type::PktType,
 };
 
-#[derive(Debug)]
-pub struct Map {
-    pub rooms: HashMap<u16, Room>,
-    pub players: HashMap<String, pkt_character::Character>,
-    pub desc: String,
-}
-
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Room {
     pub room_number: u16,
@@ -42,183 +35,178 @@ pub struct Monster {
     pub desc: String,
 }
 
-impl Map {
-    pub fn new(rooms: HashMap<u16, Room>) -> Self {
-        Map {
-            rooms,
-            players: HashMap::new(),
-            desc: String::new(),
+pub fn build(data: File) -> Result<HashMap<u16, Room>, serde_json::Error> {
+    let mut rooms: HashMap<u16, Room> = HashMap::new();
+
+    info!("[MAP] Building game map...");
+
+    let deserialized: Vec<Room> = serde_json::from_reader(&data)?;
+    info!("[MAP] Game map built with {} rooms.", deserialized.len());
+
+    for room in deserialized {
+        rooms.insert(room.room_number, room);
+    }
+
+    Ok(rooms)
+}
+
+pub fn exits(rooms: &HashMap<u16, Room>, room_number: u16) -> Option<HashMap<u16, Connection>> {
+    rooms.get(&room_number).map(|room| room.connections.clone())
+}
+
+pub fn add_player(
+    players: &mut HashMap<String, pkt_character::Character>,
+    player: pkt_character::Character,
+) {
+    players.insert(player.name.clone(), player);
+}
+
+pub fn player_from_stream(
+    players: &mut HashMap<String, pkt_character::Character>,
+    stream: Stream,
+) -> Option<(&String, &mut pkt_character::Character)> {
+    players.iter_mut().find(|(_, player)| {
+        let author = player.author.as_ref().ok_or_else(|| false);
+
+        match author {
+            Ok(author) => Arc::ptr_eq(&author, &stream),
+            Err(_) => false,
         }
+    })
+}
+
+/// Broadcast a message to all players in the game via Message packets.
+pub fn broadcast(
+    players: &HashMap<String, pkt_character::Character>,
+    message: String,
+) -> Result<(), std::io::Error> {
+    info!("[BROADCAST] Sending message: {}", message);
+
+    // Send the packet to the server
+    for (_, player) in players {
+        let author = player
+            .author
+            .as_ref()
+            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Author not found"))?;
+
+        debug!("[BROADCAST] Sending message to {}", player.name);
+
+        Protocol::Message(
+            author.clone(),
+            pkt_message::Message {
+                message_type: PktType::Message,
+                message_len: message.len() as u16,
+                recipient: player.name.clone(),
+                sender: "Server".to_string(),
+                narration: false,
+                message: message.clone(),
+            },
+        )
+        .send()
+        .unwrap_or_else(|e| {
+            warn!(
+                "[BROADCAST] Failed to send message to {}: {}",
+                player.name, e
+            );
+        });
     }
 
-    pub fn build(data: File) -> Result<Self, serde_json::Error> {
-        let mut rooms: HashMap<u16, Room> = HashMap::new();
+    Ok(())
+}
 
-        info!("[MAP] Building game map...");
+pub fn message_room(
+    players: &HashMap<String, pkt_character::Character>,
+    rooms: &HashMap<u16, Room>,
+    room_number: u16,
+    message: String,
+) -> Result<(), std::io::Error> {
+    info!(
+        "[ROOM MESSAGE] Sending message to room {}: {}",
+        room_number, message
+    );
 
-        let deserialized: Vec<Room> = serde_json::from_reader(&data)?;
-        info!("[MAP] Game map built with {} rooms.", deserialized.len());
+    let room = rooms
+        .get(&room_number)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Room not found"))?;
 
-        for room in deserialized {
-            rooms.insert(room.room_number, room);
-        }
-
-        Ok(Map::new(rooms))
-    }
-
-    pub fn add_player(&mut self, player: pkt_character::Character) {
-        self.players.insert(player.name.clone(), player);
-    }
-
-    pub fn player_from_name(&mut self, name: &String) -> Option<&mut pkt_character::Character> {
-        self.players.get_mut(name)
-    }
-
-    pub fn player_from_stream(
-        &mut self,
-        stream: &Stream,
-    ) -> Option<(&String, &mut pkt_character::Character)> {
-        self.players.iter_mut().find(|(_, player)| {
-            let author = player.author.as_ref().ok_or_else(|| false);
-
-            match author {
-                Ok(author) => Arc::ptr_eq(&author, stream),
-                Err(_) => false,
+    room.players.iter().for_each(|name| {
+        let player = match players.get(name) {
+            Some(player) => player,
+            None => {
+                error!("[ROOM MESSAGE] Player '{}' doesn't exist!", name);
+                return;
             }
-        })
-    }
+        };
 
-    pub fn exits(&self, room_number: u16) -> Option<HashMap<u16, Connection>> {
-        self.rooms
-            .get(&room_number)
-            .map(|room| room.connections.clone())
-    }
+        let author = match player.author.as_ref() {
+            Some(author) => author,
+            None => {
+                warn!("[ROOM MESSAGE] Player '{}' is not connected", name);
+                return;
+            }
+        };
 
-    /// Broadcast a message to all players in the game via Message packets.
-    pub fn broadcast(&self, message: String) -> Result<(), std::io::Error> {
-        info!("[BROADCAST] Sending message: {}", message);
+        debug!("[ROOM MESSAGE] Sending message to '{}'", name);
 
-        // Send the packet to the server
-        for (_, player) in &self.players {
-            let author = player.author.as_ref().ok_or_else(|| {
-                std::io::Error::new(std::io::ErrorKind::NotFound, "Author not found")
-            })?;
+        Protocol::Message(
+            author.clone(),
+            pkt_message::Message {
+                message_type: PktType::Message,
+                message_len: message.len() as u16,
+                recipient: player.name.clone(),
+                sender: "Narrator".to_string(),
+                narration: true,
+                message: message.clone(),
+            },
+        )
+        .send()
+        .unwrap_or_else(|e| {
+            error!("[ROOM MESSAGE] Failed to send message to '{}': {}", name, e);
+        });
+    });
 
-            debug!("[BROADCAST] Sending message to {}", player.name);
+    Ok(())
+}
 
-            Protocol::Message(
-                author.clone(),
-                pkt_message::Message {
-                    message_type: PktType::Message,
-                    message_len: message.len() as u16,
-                    recipient: player.name.clone(),
-                    sender: "Server".to_string(),
-                    narration: false,
-                    message: message.clone(),
-                },
-            )
+/// Alert all players in the current room of a character change by sending a Character packet
+/// to each player in the room.
+pub fn alert_room(
+    players: &HashMap<String, pkt_character::Character>,
+    rooms: &HashMap<u16, Room>,
+    room_number: u16,
+    player: &pkt_character::Character,
+) -> Result<(), std::io::Error> {
+    info!("[ALERT] Alerting players about: '{}'", player.name);
+
+    let room = rooms
+        .get(&room_number)
+        .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Room not found"))?;
+
+    room.players.iter().for_each(|name| {
+        debug!("[ALERT] Alerting player: '{}'", name);
+
+        let player = match players.get(name) {
+            Some(player) => player,
+            None => {
+                error!("[ALERT] Player '{}' doesn't exist!", name);
+                return;
+            }
+        };
+
+        let author = match player.author.as_ref() {
+            Some(author) => author,
+            None => {
+                warn!("[ALERT] Player '{}' is not connected", player.name);
+                return;
+            }
+        };
+
+        Protocol::Character(author.clone(), player.clone())
             .send()
             .unwrap_or_else(|e| {
-                warn!(
-                    "[BROADCAST] Failed to send message to {}: {}",
-                    player.name, e
-                );
-            });
-        }
+                error!("[ALERT] Failed to alert '{}': {}", name, e);
+            })
+    });
 
-        Ok(())
-    }
-
-    pub fn message_room(&self, room_number: u16, message: String) -> Result<(), std::io::Error> {
-        info!(
-            "[ROOM MESSAGE] Sending message to room {}: {}",
-            room_number, message
-        );
-
-        let room = self
-            .rooms
-            .get(&room_number)
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Room not found"))?;
-
-        room.players.iter().for_each(|name| {
-            let player = match self.players.get(name) {
-                Some(player) => player,
-                None => {
-                    error!("[ROOM MESSAGE] Player '{}' doesn't exist!", name);
-                    return;
-                }
-            };
-
-            let author = match player.author.as_ref() {
-                Some(author) => author,
-                None => {
-                    warn!("[ROOM MESSAGE] Player '{}' is not connected", name);
-                    return;
-                }
-            };
-
-            debug!("[ROOM MESSAGE] Sending message to '{}'", name);
-
-            Protocol::Message(
-                author.clone(),
-                pkt_message::Message {
-                    message_type: PktType::Message,
-                    message_len: message.len() as u16,
-                    recipient: player.name.clone(),
-                    sender: "Narrator".to_string(),
-                    narration: true,
-                    message: message.clone(),
-                },
-            )
-            .send()
-            .unwrap_or_else(|e| {
-                error!("[ROOM MESSAGE] Failed to send message to '{}': {}", name, e);
-            });
-        });
-
-        Ok(())
-    }
-
-    /// Alert all players in the current room of a character change by sending a Character packet
-    /// to each player in the room.
-    pub fn alert_room(
-        &self,
-        room_number: u16,
-        player: &pkt_character::Character,
-    ) -> Result<(), std::io::Error> {
-        info!("[ALERT] Alerting players about: '{}'", player.name);
-
-        let room = self
-            .rooms
-            .get(&room_number)
-            .ok_or_else(|| std::io::Error::new(std::io::ErrorKind::NotFound, "Room not found"))?;
-
-        room.players.iter().for_each(|name| {
-            debug!("[ALERT] Alerting player: '{}'", name);
-
-            let player = match self.players.get(name) {
-                Some(player) => player,
-                None => {
-                    error!("[ALERT] Player '{}' doesn't exist!", name);
-                    return;
-                }
-            };
-
-            let author = match player.author.as_ref() {
-                Some(author) => author,
-                None => {
-                    warn!("[ALERT] Player '{}' is not connected", player.name);
-                    return;
-                }
-            };
-
-            Protocol::Character(author.clone(), player.clone())
-                .send()
-                .unwrap_or_else(|e| {
-                    error!("[ALERT] Failed to alert '{}': {}", name, e);
-                })
-        });
-
-        Ok(())
-    }
+    Ok(())
 }

--- a/src/protocol/game.rs
+++ b/src/protocol/game.rs
@@ -10,7 +10,7 @@ use crate::protocol::{
 
 #[derive(Debug)]
 pub struct Map {
-    pub rooms: Vec<Room>,
+    pub rooms: Vec<Room>, //TODO: Also change to HasMap and use the room id as the key
     pub players: HashMap<String, pkt_character::Character>,
     pub desc: String,
 }

--- a/src/protocol/game.rs
+++ b/src/protocol/game.rs
@@ -19,7 +19,7 @@ pub struct Map {
 pub struct Room {
     pub room_number: u16,
     pub title: String,
-    pub connections: Vec<Connection>,
+    pub connections: HashMap<u16, Connection>,
     pub desc: String,
     pub players: Vec<String>,
     pub monsters: Option<Vec<Monster>>,
@@ -88,7 +88,7 @@ impl Map {
         })
     }
 
-    pub fn exits(&self, room_number: u16) -> Option<Vec<Connection>> {
+    pub fn exits(&self, room_number: u16) -> Option<HashMap<u16, Connection>> {
         self.rooms
             .get(&room_number)
             .map(|room| room.connections.clone())

--- a/src/protocol/packet/pkt_character.rs
+++ b/src/protocol/packet/pkt_character.rs
@@ -3,7 +3,7 @@ use std::os::fd::AsRawFd;
 use std::{fmt::LowerHex, os::fd::AsFd};
 use tracing::debug;
 
-use crate::protocol::map::Monster;
+use crate::protocol::game::Monster;
 use crate::protocol::{
     Stream,
     packet::{Packet, Parser},

--- a/src/protocol/packet/pkt_connection.rs
+++ b/src/protocol/packet/pkt_connection.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use tracing::debug;
 
 use crate::protocol::{
-    map,
+    game,
     packet::{Packet, Parser},
     pcap::PCap,
     pkt_type::PktType,
@@ -18,9 +18,9 @@ pub struct Connection {
     pub description: String,
 }
 
-impl From<&map::Connection> for Connection {
+impl From<&game::Connection> for Connection {
     /// Create a new connection from the game map to send to the client
-    fn from(conn: &map::Connection) -> Self {
+    fn from(conn: &game::Connection) -> Self {
         Connection {
             message_type: PktType::Connection,
             room_number: conn.room_number,

--- a/src/protocol/packet/pkt_room.rs
+++ b/src/protocol/packet/pkt_room.rs
@@ -3,7 +3,7 @@ use std::io::Write;
 use tracing::debug;
 
 use crate::protocol::{
-    map,
+    game,
     packet::{Packet, Parser},
     pcap::PCap,
     pkt_type::PktType,
@@ -41,8 +41,8 @@ impl Room {
     }
 }
 
-impl From<map::Room> for Room {
-    fn from(room: map::Room) -> Self {
+impl From<game::Room> for Room {
+    fn from(room: game::Room) -> Self {
         Room {
             message_type: PktType::Room,
             room_number: room.room_number,

--- a/src/threads/processor.rs
+++ b/src/threads/processor.rs
@@ -5,7 +5,7 @@ use tracing::{error, info, warn};
 use crate::protocol::packet::{pkt_game, pkt_leave, pkt_version};
 use crate::protocol::{Protocol, Stream, client::Client, pkt_type::PktType};
 
-pub fn connection(stream: Stream, initial_points: u16, stat_limit: u16, sender: Sender<Protocol>) {
+pub fn connection(stream: Stream, sender: Sender<Protocol>) {
     let client = Client::new(stream.clone(), sender);
 
     let filepath = env::var("DESC_FILEPATH").expect("[CONNECT] DESC_FILEPATH must be set.");
@@ -39,8 +39,14 @@ pub fn connection(stream: Stream, initial_points: u16, stat_limit: u16, sender: 
         stream.clone(),
         pkt_game::Game {
             message_type: PktType::Game,
-            initial_points,
-            stat_limit,
+            initial_points: env::var("INITIAL_POINTS")
+                .expect("[MAP] INITIAL_POINTS must be set.")
+                .parse()
+                .expect("[MAP] Failed to parse INITIAL_POINTS"),
+            stat_limit: env::var("STAT_LIMIT")
+                .expect("[MAP] STAT_LIMIT must be set.")
+                .parse()
+                .expect("[MAP] Failed to parse STAT_LIMIT"),
             description_len: description.len() as u16,
             description,
         },

--- a/src/threads/server.rs
+++ b/src/threads/server.rs
@@ -4,7 +4,7 @@ use tracing::{debug, error, info, warn};
 use crate::protocol::packet::{
     pkt_accept, pkt_character, pkt_character::CharacterFlags, pkt_connection, pkt_error, pkt_room,
 };
-use crate::protocol::{Protocol, error::ErrorCode, map::Map, pkt_type::PktType};
+use crate::protocol::{Protocol, error::ErrorCode, game::Map, pkt_type::PktType};
 
 pub fn server(receiver: Arc<Mutex<Receiver<Protocol>>>, map: &mut Map) {
     loop {


### PR DESCRIPTION
## Features
In order to fix some issues with multiple mutability borrows I have separated the rooms vector and player's vector entirely.

Along with that I have implemented #13
- Rooms are now a HashMap with the room ID and the unique key
- Players now use a HashMap with their name as the key so I don't have to keep track of their index in the map list...
> _Why did I think that was a good idea?_