### PR TITLE
added start.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,3 @@
 /logs
 .env
 /.vscode
-
-start.sh

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+mkdir -p logs
+
+while true
+do
+    stdbuf -oL ./target/release/ImprovedLurk --port $1 2>&1 | tee -a ./logs/serverlog_`date +%m_%d_%y_%s`.log
+    echo CRASH at `date` | tee -a ./logs/lurk_crash.log
+    sleep 120
+done


### PR DESCRIPTION
un-ignored the start.sh script and added more functionality.
`start.sh PORT`

## Important
You must build the project first `cargo build --release` for the target folder to populate, otheriwse it will fail to start.